### PR TITLE
Corrected json parse error in utils.mjs, which was causing a cart error

### DIFF
--- a/src/js/utils.mjs
+++ b/src/js/utils.mjs
@@ -7,10 +7,7 @@ export function qs(selector, parent = document) {
 
 // retrieve data from localstorage
 export function getLocalStorage(key) {
-
-  let cart = localStorage.getItem(key);
-
-  return cart;
+  return JSON.parse(localStorage.getItem(key));
 }
 // save data to local storage
 export function setLocalStorage(key, data) {


### PR DESCRIPTION
There was an error in trying to run the shopping cart. I identified that it was likely a JSON parse error. Adjusted the getLocalStorage function to rectify this.